### PR TITLE
Replace #fff with #ffffff to prevent error E254

### DIFF
--- a/colors/cobalt2.vim
+++ b/colors/cobalt2.vim
@@ -83,7 +83,7 @@ hi link Macro Include
 hi Type guifg=#ffc500 ctermfg=203 guibg=NONE ctermbg=NONE gui=italic cterm=italic
 hi link StorageClass Keyword
 hi Structure guifg=#ffc500 ctermfg=31 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi Typedef guifg=#fff ctermfg=31 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi Typedef guifg=#ffffff ctermfg=31 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi link Special Keyword
 hi Tag guifg=#7AFFFF ctermfg=31 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi SpecialComment guifg=#0088ff ctermfg=14 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
"Error detected while processing .../plugged/cobalt2/colors/cobalt2.vim:
line   86:
E254: Cannot allocate color #fff"